### PR TITLE
support burn token

### DIFF
--- a/contracts/BRWLERC20.sol
+++ b/contracts/BRWLERC20.sol
@@ -1,7 +1,7 @@
 pragma solidity ^0.6.0;
 
 import "@openzeppelin/contracts-ethereum-package/contracts/Initializable.sol";
-import "@openzeppelin/contracts-ethereum-package/contracts/token/ERC20/ERC20.sol";
+import "@openzeppelin/contracts-ethereum-package/contracts/token/ERC20/ERC20Burnable.sol";
 import "@openzeppelin/contracts-ethereum-package/contracts/GSN/Context.sol";
 
 /**
@@ -10,7 +10,7 @@ import "@openzeppelin/contracts-ethereum-package/contracts/GSN/Context.sol";
  *  - 1 trillion preminted tokens
  *
  */
-contract BRWLERC20UpgradeSafe is Initializable, ContextUpgradeSafe, ERC20UpgradeSafe {
+contract BRWLERC20UpgradeSafe is Initializable, ContextUpgradeSafe, ERC20BurnableUpgradeSafe {
     uint8 public constant DECIMALS = 4;                         // The number of decimals for display
 
     /**


### PR DESCRIPTION
Since we just add two more methods `burn` and `burnFrom` without any state variables. Contract can be upgrade safety. Deploy old version and then upgrade in Rinkeby and Ropsten, it's working perfectly. Tested contract on Ropsten (https://ropsten.etherscan.io/token/0x3804407aa0d5ddfBf68B1f3461e4bF923d6FE9e5)

- update to inherit from ERC20BurnableUpgradeSafe
- update unit test